### PR TITLE
Fix order of docstring and 'interactive

### DIFF
--- a/css-eldoc.el
+++ b/css-eldoc.el
@@ -57,15 +57,15 @@
 
 ;;;###autoload
 (defun css-eldoc-enable ()
-  (interactive)
   "Turn on css-eldoc in buffers where `css-mode' is active."
+  (interactive)
   (add-hook 'css-mode-hook
             #'turn-on-css-eldoc))
 
 ;;;###autoload
 (defun css-eldoc-disable ()
-  (interactive)
   "Disable css-eldoc."
+  (interactive)
   (remove-hook 'css-mode-hook #'turn-on-css-eldoc))
 
 (provide 'css-eldoc)


### PR DESCRIPTION
Just a minor fix following the patch from @expez... :-)
