### PR TITLE
(eldoc-mode 1)

### DIFF
--- a/css-eldoc.el
+++ b/css-eldoc.el
@@ -52,6 +52,7 @@
                                   (gethash property css-eldoc-hash-table))))))
 
 (defun turn-on-css-eldoc ()
+  "Turn on css-eldoc in this buffer."
   (set (make-local-variable 'eldoc-documentation-function) 'css-eldoc-function)
   (eldoc-mode 1))
 

--- a/css-eldoc.el
+++ b/css-eldoc.el
@@ -53,7 +53,7 @@
 
 (defun turn-on-css-eldoc ()
   (set (make-local-variable 'eldoc-documentation-function) 'css-eldoc-function)
-  (eldoc-mode))
+  (eldoc-mode 1))
 
 ;;;###autoload
 (defun css-eldoc-enable ()


### PR DESCRIPTION
Simply calling `(eldoc-mode)` can turn it off instead of turning it on, if it is already enabled in the current buffer.

Adding an explicit argument to the function makes the function idempotent.

----

#